### PR TITLE
Finish renaming pts mode

### DIFF
--- a/uroboro-mode.el
+++ b/uroboro-mode.el
@@ -14,7 +14,7 @@
 
 (defvar uroboro-font-lock-defaults
   `((,(regexp-opt uroboro-keywords 'words) . 'font-lock-keyword-face)
-    (,(concat "[" pts-interpunctuation "]") . 'font-lock-builtin-face))
+    (,(concat "[" uroboro-interpunctuation "]") . 'font-lock-builtin-face))
   "Font lock configuration for Uroboro.")
 
 (defvar uroboro-command


### PR DESCRIPTION
Currentlty, this code fails (complaining about pts-interpunctuation not being
defined) unless loaded after pts-mode. Fix that.
